### PR TITLE
Introduce database persistence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,15 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/de/schulung/spring/customers/persistence/database/CustomerEntity.java
+++ b/src/main/java/de/schulung/spring/customers/persistence/database/CustomerEntity.java
@@ -20,6 +20,7 @@ public class CustomerEntity {
   private String name;
   @Column(name = "BIRTH_DATE")
   private LocalDate birthdate;
+  // @Enumerated(EnumType.STRING)
   private CustomerState state;
 
 

--- a/src/main/java/de/schulung/spring/customers/persistence/database/CustomerEntity.java
+++ b/src/main/java/de/schulung/spring/customers/persistence/database/CustomerEntity.java
@@ -1,0 +1,26 @@
+package de.schulung.spring.customers.persistence.database;
+
+import de.schulung.spring.customers.domain.CustomerState;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Entity(name = "Customer")
+@Table(name = "CUSTOMERS")
+public class CustomerEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID uuid;
+  private String name;
+  @Column(name = "BIRTH_DATE")
+  private LocalDate birthdate;
+  private CustomerState state;
+
+
+}

--- a/src/main/java/de/schulung/spring/customers/persistence/database/CustomerEntityMapper.java
+++ b/src/main/java/de/schulung/spring/customers/persistence/database/CustomerEntityMapper.java
@@ -1,0 +1,16 @@
+package de.schulung.spring.customers.persistence.database;
+
+import de.schulung.spring.customers.domain.Customer;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring")
+public interface CustomerEntityMapper {
+
+  CustomerEntity map(Customer source);
+
+  Customer map(CustomerEntity source);
+
+  void copy(CustomerEntity source, @MappingTarget Customer target);
+
+}

--- a/src/main/java/de/schulung/spring/customers/persistence/database/CustomerEntityRepository.java
+++ b/src/main/java/de/schulung/spring/customers/persistence/database/CustomerEntityRepository.java
@@ -1,0 +1,20 @@
+package de.schulung.spring.customers.persistence.database;
+
+
+import de.schulung.spring.customers.domain.CustomerState;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface CustomerEntityRepository
+  extends JpaRepository<CustomerEntity, UUID> {
+
+  List<CustomerEntity> findAllByState(CustomerState state);
+
+  // @Query("SELECT c FROM Customer c WHERE c.state = :state")
+  // List<CustomerEntity> gelbeKatze(@Param("state") CustomerState state);
+
+}

--- a/src/main/java/de/schulung/spring/customers/persistence/database/CustomerStateConverter.java
+++ b/src/main/java/de/schulung/spring/customers/persistence/database/CustomerStateConverter.java
@@ -1,0 +1,29 @@
+package de.schulung.spring.customers.persistence.database;
+
+import de.schulung.spring.customers.domain.CustomerState;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class CustomerStateConverter
+  implements AttributeConverter<CustomerState, String> {
+
+  @Override
+  public String convertToDatabaseColumn(CustomerState attribute) {
+    return null == attribute ? null : switch (attribute) {
+      case ACTIVE -> "a";
+      case LOCKED -> "l";
+      case DISABLED -> "d";
+    };
+  }
+
+  @Override
+  public CustomerState convertToEntityAttribute(String dbData) {
+    return null == dbData ? null : switch (dbData) {
+      case "a" -> CustomerState.ACTIVE;
+      case "l" -> CustomerState.LOCKED;
+      case "d" -> CustomerState.DISABLED;
+      default -> throw new IllegalStateException("Unexpected value: " + dbData);
+    };
+  }
+}

--- a/src/main/java/de/schulung/spring/customers/persistence/database/JpaCustomersSink.java
+++ b/src/main/java/de/schulung/spring/customers/persistence/database/JpaCustomersSink.java
@@ -1,0 +1,66 @@
+package de.schulung.spring.customers.persistence.database;
+
+import de.schulung.spring.customers.domain.Customer;
+import de.schulung.spring.customers.domain.CustomerState;
+import de.schulung.spring.customers.domain.CustomersSink;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+@RequiredArgsConstructor
+public class JpaCustomersSink
+  implements CustomersSink {
+
+  private final CustomerEntityRepository repo;
+  private final CustomerEntityMapper mapper;
+
+  @Override
+  public Stream<Customer> findAll() {
+    return repo
+      .findAll()
+      .stream()
+      .map(mapper::map);
+  }
+
+  @Override
+  public Stream<Customer> findAllByState(CustomerState state) {
+    return repo
+      .findAllByState(state)
+      .stream()
+      .map(mapper::map);
+  }
+
+  @Override
+  public Optional<Customer> findById(UUID uuid) {
+    return repo
+      .findById(uuid)
+      .map(mapper::map);
+  }
+
+  @Override
+  public long count() {
+    return repo
+      .count();
+  }
+
+  @Override
+  public void create(Customer customer) {
+    var entity = mapper.map(customer);
+    repo
+      .save(entity);
+    // customer.setUuid(entity.getUuid());
+    mapper.copy(entity, customer);
+  }
+
+  @Override
+  public boolean delete(UUID uuid) {
+    if (!repo.existsById(uuid)) {
+      return false;
+    }
+    repo
+      .deleteById(uuid);
+    return true;
+  }
+}

--- a/src/main/java/de/schulung/spring/customers/persistence/database/JpaCustomersSinkConfiguration.java
+++ b/src/main/java/de/schulung/spring/customers/persistence/database/JpaCustomersSinkConfiguration.java
@@ -1,0 +1,22 @@
+package de.schulung.spring.customers.persistence.database;
+
+import de.schulung.spring.customers.domain.CustomersSink;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+// @ConditionalOnProperty... - Schalter zum Deaktivieren
+@Configuration
+public class JpaCustomersSinkConfiguration {
+
+  @Bean
+  CustomersSink jpaCustomersSink(
+    CustomerEntityRepository repo,
+    CustomerEntityMapper mapper
+  ) {
+    return new JpaCustomersSink(
+      repo,
+      mapper
+    );
+  }
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,3 +4,13 @@ application:
     allowed-origins: '*.swagger.io'
   initialization:
     enabled: true
+spring:
+  datasource:
+    url: jdbc:h2:./.local-db/customers
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: update
+  h2:
+    console:
+      enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,14 @@ spring:
     deserialization:
       fail-on-unknown-properties: true
       fail-on-ignored-properties: true
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+  jpa:
+    #hibernate:
+    #ddl-auto: validate
+    show-sql: ${DB_SHOW_SQL:false}
 application:
   initialization:
     enabled: ${APP_INITIALIZATION_ENABLED:false}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -8,6 +8,7 @@
 <h1>Welcome to the Customer API!</h1>
 <ul>
   <li><a href="openapi.yml">Open API</a></li>
+  <li><a href="h2-console">H2 Console</a></li>
 </ul>
 </body>
 </html>

--- a/src/test/java/de/schulung/spring/customers/boundary/CorsTests.java
+++ b/src/test/java/de/schulung/spring/customers/boundary/CorsTests.java
@@ -2,6 +2,7 @@ package de.schulung.spring.customers.boundary;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
@@ -17,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
   }
 )
 @AutoConfigureMockMvc
+@AutoConfigureTestDatabase
 class CorsTests {
 
   @Autowired

--- a/src/test/java/de/schulung/spring/customers/boundary/CustomerApiTests.java
+++ b/src/test/java/de/schulung/spring/customers/boundary/CustomerApiTests.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@AutoConfigureTestDatabase
 class CustomerApiTests {
 
   @Autowired

--- a/src/test/java/de/schulung/spring/customers/boundary/CustomerApiWithMockedServiceTests.java
+++ b/src/test/java/de/schulung/spring/customers/boundary/CustomerApiWithMockedServiceTests.java
@@ -3,8 +3,8 @@ package de.schulung.spring.customers.boundary;
 import de.schulung.spring.customers.domain.CustomersService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -13,15 +13,15 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@WebMvcTest
+@ComponentScan(
+  basePackageClasses = CustomerDtoMapper.class
+)
 public class CustomerApiWithMockedServiceTests {
 
   @Autowired

--- a/src/test/java/de/schulung/spring/customers/boundary/StaticResourcesTests.java
+++ b/src/test/java/de/schulung/spring/customers/boundary/StaticResourcesTests.java
@@ -2,6 +2,7 @@ package de.schulung.spring.customers.boundary;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
@@ -13,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@AutoConfigureTestDatabase
 class StaticResourcesTests {
 
   @Autowired

--- a/src/test/java/de/schulung/spring/customers/domain/CustomerInitializationDisabledTests.java
+++ b/src/test/java/de/schulung/spring/customers/domain/CustomerInitializationDisabledTests.java
@@ -2,6 +2,7 @@ package de.schulung.spring.customers.domain;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.verify;
     "application.initialization.enabled=false",
   }
 )
+@AutoConfigureTestDatabase
 @Import(CustomerInitializationDisabledTests.MockConfiguration.class)
 class CustomerInitializationDisabledTests {
 

--- a/src/test/java/de/schulung/spring/customers/domain/CustomerInitializationWithEmptyCustomersTests.java
+++ b/src/test/java/de/schulung/spring/customers/domain/CustomerInitializationWithEmptyCustomersTests.java
@@ -2,6 +2,7 @@ package de.schulung.spring.customers.domain;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.when;
     "application.initialization.enabled=true",
   }
 )
+@AutoConfigureTestDatabase
 @Import(CustomerInitializationWithEmptyCustomersTests.MockConfiguration.class)
 class CustomerInitializationWithEmptyCustomersTests {
 

--- a/src/test/java/de/schulung/spring/customers/domain/CustomerInitializationWithNonEmptyCustomersTests.java
+++ b/src/test/java/de/schulung/spring/customers/domain/CustomerInitializationWithNonEmptyCustomersTests.java
@@ -2,6 +2,7 @@ package de.schulung.spring.customers.domain;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.when;
     "application.initialization.enabled=true",
   }
 )
+@AutoConfigureTestDatabase
 @Import(CustomerInitializationWithNonEmptyCustomersTests.MockConfiguration.class)
 class CustomerInitializationWithNonEmptyCustomersTests {
 

--- a/src/test/java/de/schulung/spring/customers/domain/CustomersServiceTests.java
+++ b/src/test/java/de/schulung/spring/customers/domain/CustomersServiceTests.java
@@ -2,6 +2,7 @@ package de.schulung.spring.customers.domain;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDate;
@@ -11,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
+@AutoConfigureTestDatabase
 class CustomersServiceTests {
 
   @Autowired


### PR DESCRIPTION
# Weiterführende Informationen
- [Beispiel für JPA Entities mit Relationen](https://github.com/ralf-ueberfuhr-ars/spring-data-2023-05-09/tree/main/src/main/java/de/sample/spring/customers/entities)
- Fallstricke bei JPA:
  - Mapping von Enums
  - 1:n/m:n-Beziehungen werden Lazy (bei Aufruf des Getters) geladen, falls nicht explizit per FetchType anders angegeben ([N+1-Problem](https://medium.com/@liberatoreanita/analyze-and-understand-the-n-1-problem-in-hibernate-920cbc056705))
    - Vorsicht bei `hashCode()`/`equals()`/`toString()`, v.a. wenn von Lombok generiert - dann per Lombok-Annotation ausschließen
    - Vorsicht bei MapStruct-Mappern ([Lösungsmöglichkeit](https://github.com/ueberfuhr-trainings/spring-boot-graphql-2024-04-04/blob/main/src/main/java/com/samples/spring/persistence/jpa/BlogPostEntityMapper.java))
  - 1:1/n:1-Beziehungen werden Eager (sofort) geladen, falls nicht explizit per FetchType anders angegeben
    - Vorsicht bei großen Daten (CLOBs, BLOBs)